### PR TITLE
Prevent livejs from running if elements are not in DOM

### DIFF
--- a/live/live.js
+++ b/live/live.js
@@ -31,7 +31,12 @@ function CountDownTimer(dt)
         document.getElementById('sec').innerHTML += seconds;
     }
 
-    timer = setInterval(showRemaining, 1000);
+    if (document.getElementById('days')
+            && document.getElementById('hours')
+            && document.getElementById('min')
+            && document.getElementById('sec')) {
+        timer = setInterval(showRemaining, 1000);
+    }
 }
 
 $(document).ready(function() {


### PR DESCRIPTION
Previously, livejs was being loaded and run on all sub-folder pages such as api, hardware, prize, etc. This filled the console with errors as it was trying to edit non-existing elements every second.

This fix checks if the elements it wishes to edit exist within the dom before setting the timer.